### PR TITLE
Moved the giveaways list area to bottom

### DIFF
--- a/app/src/main/event/views/event.html
+++ b/app/src/main/event/views/event.html
@@ -3,32 +3,10 @@
 <div class="row">
     <!-- LEFT COLUMN -->
     <div class="col-md-9">
-        <button ng-click="event.openCreateGiveawayModal()" class="btn btn-primary btn-sm pull-right" style="margin: 20px 14px 0 0;"><span class="glyphicon glyphicon-plus"></span></button>
-        <h4 class="subtitle">Giveaways <span class="label label-warning">{{event.countGiveaways()}}</span></h4>
-
-        <div class="giveaways">
-            <div class="row giveaway" ng-repeat="giveaway in event.giveaways">
-                <div class="col-sm-1 text-center">
-                    <img ng-src="{{giveaway.prize.imageUrl}}" class="img-responsive" />
-                </div>
-                <div class="col-sm-5">
-                    <b>{{giveaway.amount}} &times; {{giveaway.prize.name}}</b>
-                    <br /><span class="label label-warning" ng-if="giveaway.emailRequired">Requires e-mail</span>
-                </div>
-                <div class="col-sm-4">
-                    <span ng-repeat="winner in event.winners[giveaway.id]">{{winner}}, </span>
-                </div>
-                <div class="col-sm-2 text-right" ng-if="event.canUpdateGiveaway(giveaway.id)">
-                    <button class="btn btn-xs" ng-click="event.selectGiveawayToUpdate(giveaway.id)"><span class="fui-new"></span></button>
-                    <button class="btn btn-xs" ng-click="event.deleteGiveaway(giveaway.id)"><span class="fui-trash"></span></button>
-                </div>
-            </div>
-        </div>
-
 
         <div class="draw-area" ng-show="event.canDrawGiveaway()">
             <p class="text-center">Currently drawing</p>
-            <h3 class="text-center">{{event.nextGiveaway().prize.name}}</h3>
+            <h3 class="text-center">{{event.nextGiveaway().prize.name}}</h3><br/>
 
             <div ng-if="event.winnerDrawn()" style="margin:40px 0;">
                 <p class="text-center"><img src="https://cdn4.iconfinder.com/data/icons/PixeloPhilia_2/PNG/medal.png" /> And the winner is...</p>
@@ -53,7 +31,29 @@
             <img src="https://cdn1.iconfinder.com/data/icons/powerful-seo-icon-set/512/ribbon_1__.png" />
             <h3>That's all folks! Congratulations!</h3>
 
-            <p><a ng-href="{{event.downloadCsvUrl()}}">Download results in CSV file</a></p>
+            <p><a ng-href="{{event.downloadCsvUrl()}}">Download results in CSV file</a></p><br/>
+        </div>
+
+        <button ng-click="event.openCreateGiveawayModal()" class="btn btn-primary btn-sm pull-right" style="margin: 20px 14px 0 0;"><span class="glyphicon glyphicon-plus"></span></button>
+        <h4 class="subtitle">Giveaways <span class="label label-warning">{{event.countGiveaways()}}</span></h4>
+
+        <div class="giveaways">
+            <div class="row giveaway" ng-repeat="giveaway in event.giveaways">
+                <div class="col-sm-1 text-center">
+                    <img ng-src="{{giveaway.prize.imageUrl}}" class="img-responsive" />
+                </div>
+                <div class="col-sm-5">
+                    <b>{{giveaway.amount}} &times; {{giveaway.prize.name}}</b>
+                    <br /><span class="label label-warning" ng-if="giveaway.emailRequired">Requires e-mail</span>
+                </div>
+                <div class="col-sm-4">
+                    <span ng-repeat="winner in event.winners[giveaway.id]">{{winner}}, </span>
+                </div>
+                <div class="col-sm-2 text-right" ng-if="event.canUpdateGiveaway(giveaway.id)">
+                    <button class="btn btn-xs" ng-click="event.selectGiveawayToUpdate(giveaway.id)"><span class="fui-new"></span></button>
+                    <button class="btn btn-xs" ng-click="event.deleteGiveaway(giveaway.id)"><span class="fui-trash"></span></button>
+                </div>
+            </div>
         </div>
 
     </div>


### PR DESCRIPTION
Moved the giveaways list to bottom of the page. It seems more user friendly as the main function of this screen is to draw gifts. Example (once all is drawn) below

![screenshot-127 0 0 1-8000-2019 04 01-20-17-43](https://user-images.githubusercontent.com/7403841/55350323-1a19e400-54bc-11e9-988b-b174738c0f91.png)